### PR TITLE
Directory in the output filename + parent_id + time spent

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 from __future__ import print_function
 
@@ -218,7 +218,6 @@ def main(argv):
     parser.add_argument('--output', '-o', help='Output filename (output format is line delimited JSON)')
     parser.add_argument('--limit', '-l', type=int, help='Limit the number of comments')
 
-    start_time = time.time()
     try:
         args = parser.parse_args(argv)
 
@@ -233,13 +232,14 @@ def main(argv):
         if '/' in output:
             outdir = output.rsplit('/', maxsplit=1)[0]
             if not os.path.exists(outdir):
-                os.mkdir(outdir)
+                os.makedirs(outdir)
 
         print('Downloading Youtube comments for video:', youtube_id)
         count = 0
         with io.open(output, 'w', encoding='utf8') as fp:
             sys.stdout.write('Downloaded %d comment(s)\r' % count)
             sys.stdout.flush()
+            start_time = time.time()
             for comment in download_comments(youtube_id):
                 comment_json = json.dumps(comment, ensure_ascii=False)
                 print(comment_json.decode('utf-8') if isinstance(comment_json, bytes) else comment_json, file=fp)
@@ -248,7 +248,6 @@ def main(argv):
                 sys.stdout.flush()
                 if limit and count >= limit:
                     break
-        sys.stdout.write('Downloaded %d comment(s)' % count)
         print('\n[{:.2f} seconds] Done!'.format(time.time() - start_time))
 
     except Exception as e:

--- a/downloader.py
+++ b/downloader.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 
@@ -210,6 +210,7 @@ def main(argv):
     parser.add_argument('--output', '-o', help='Output filename (output format is line delimited JSON)')
     parser.add_argument('--limit', '-l', type=int, help='Limit the number of comments')
 
+    start_time = time.time()
     try:
         args = parser.parse_args(argv)
 
@@ -220,6 +221,11 @@ def main(argv):
         if not youtube_id or not output:
             parser.print_usage()
             raise ValueError('you need to specify a Youtube ID and an output filename')
+
+        if '/' in output:
+            outdir = output.rsplit('/', maxsplit=1)[0]
+            if not os.path.exists(outdir):
+                os.mkdir(outdir)
 
         print('Downloading Youtube comments for video:', youtube_id)
         count = 0
@@ -234,7 +240,8 @@ def main(argv):
                 sys.stdout.flush()
                 if limit and count >= limit:
                     break
-        print('\nDone!')
+        sys.stdout.write('Downloaded %d comment(s)' % count)
+        print('\n[{:.2f} seconds] Done!'.format(time.time() - start_time))
 
     except Exception as e:
         print('Error:', str(e))

--- a/downloader.py
+++ b/downloader.py
@@ -82,9 +82,7 @@ def download_comments_new_api(youtube_id, sleep=1):
                          for ncd in search_dict(response, 'nextContinuationData')] + continuations
 
         for comment in search_dict(response, 'commentRenderer'):
-            cid = comment['commentId']
-            yield {'cid': cid,
-                   'parent_id': cid.split('.')[0] if '.' in cid else None,
+            yield {'cid': comment['commentId'],
                    'text': ''.join([c['text'] for c in comment['contentText']['runs']]),
                    'time': comment['publishedTimeText']['runs'][0]['text'],
                    'author': comment.get('authorText', {}).get('simpleText', ''),
@@ -194,9 +192,7 @@ def extract_comments(html):
     photo_sel = CSSSelector('.user-photo')
 
     for item in item_sel(tree):
-        cid = item.get('data-cid')
-        yield {'cid': cid,
-               'parent_id': cid.split('.')[0] if '.' in cid else None,
+        yield {'cid': item.get('data-cid'),
                'text': text_sel(item)[0].text_content(),
                'time': time_sel(item)[0].text_content().strip(),
                'author': author_sel(item)[0].text_content(),
@@ -229,8 +225,8 @@ def main(argv):
             parser.print_usage()
             raise ValueError('you need to specify a Youtube ID and an output filename')
 
-        if '/' in output:
-            outdir = output.rsplit('/', maxsplit=1)[0]
+        if os.sep in output:
+            outdir = os.path.dirname(output)
             if not os.path.exists(outdir):
                 os.makedirs(outdir)
 

--- a/downloader.py
+++ b/downloader.py
@@ -80,7 +80,9 @@ def download_comments_new_api(youtube_id, sleep=1):
                          for ncd in search_dict(response, 'nextContinuationData')] + continuations
 
         for comment in search_dict(response, 'commentRenderer'):
-            yield {'cid': comment['commentId'],
+            cid = comment['commentId']
+            yield {'cid': cid,
+                   'parent_id': cid.split('.')[0] if '.' in cid else None,
                    'text': ''.join([c['text'] for c in comment['contentText']['runs']]),
                    'time': comment['publishedTimeText']['runs'][0]['text'],
                    'author': comment.get('authorText', {}).get('simpleText', ''),
@@ -189,7 +191,9 @@ def extract_comments(html):
     photo_sel = CSSSelector('.user-photo')
 
     for item in item_sel(tree):
-        yield {'cid': item.get('data-cid'),
+        cid = item.get('data-cid')
+        yield {'cid': cid,
+               'parent_id': cid.split('.')[0] if '.' in cid else None,
                'text': text_sel(item)[0].text_content(),
                'time': time_sel(item)[0].text_content().strip(),
                'author': author_sel(item)[0].text_content(),


### PR DESCRIPTION
1. If the output filename contains a directory, it would give an error. Now it creates the directory and works;
2. Added the `parent_id` of each comment. This is important to explicit the comment threads;
3. I think it's nice to have the time spent downloading the comments, so it is printed at the end too.