### PR TITLE
Adding a strip to the youtubeid

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -220,7 +220,7 @@ def main(argv):
     try:
         args = parser.parse_args(argv)
 
-        youtube_id = args.youtubeid
+        youtube_id = args.youtubeid.strip()
         output = args.output
         limit = args.limit
 


### PR DESCRIPTION
Trimming the string here will help with being able to pull comments from a youtube video whose ID starts with -

for instance:
` https://www.youtube.com/watch?v=-YeeVvw-8uo `

i've used this in a bash loop to pull a list of video comments. so, now i can do:

```
while read line; do
    ((i=i+1))
    python youtube-comment-downloader/downloader.py -y " ${line}" -o data/"${i}-${line}".json
done <data/videos
```