### PR TITLE
Provide fix for videos with '};' in the metadata (and other changes)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+regex

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 requests
-regex

--- a/youtube_comment_downloader/__main__.py
+++ b/youtube_comment_downloader/__main__.py
@@ -1,0 +1,4 @@
+from .downloader import main
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
1. Previously, the program was unable to extract comments from videos with '};' in the metadata (e.g., CHqg6qOn4no).
    ```
    $ youtube-comment-downloader --youtubeid CHqg6qOn4no --output test.json
    Downloading Youtube comments for video: CHqg6qOn4no
    Error: Unterminated string starting at: line 1 column 17793 (char 17792)
    ```

    After the changes, the script produces the following (correct) output:
    ```
    $ youtube-comment-downloader --youtubeid CHqg6qOn4no --output test.json
    Downloading Youtube comments for video: CHqg6qOn4no
    Downloaded 23 comment(s)
    [3.91 seconds] Done!
    ```
2. Since regex is used, the `find_value` method is not needed anymore.


3. The context is now directly passed to the `ajax_request` method


4. I added a `__main__.py` file to allow the program to be executed as a python module with the `-m` flag.
  
    For example:
    `python -m youtube_comment_downloader --youtubeid CHqg6qOn4no --output test.json`
    
    This helps developers test without having to reinstall the package after each change
