### PR TITLE
Fix #105

### DIFF
--- a/youtube_comment_downloader/downloader.py
+++ b/youtube_comment_downloader/downloader.py
@@ -58,7 +58,7 @@ class YoutubeCommentDownloader:
 
         data = json.loads(self.regex_search(html, YT_INITIAL_DATA_RE, default=''))
 
-        section = next(self.search_dict(data, 'itemSectionRenderer'), None)
+        section = next(self.search_dict(data['contents'], 'itemSectionRenderer'), None)
         renderer = next(self.search_dict(section, 'continuationItemRenderer'), None) if section else None
         if not renderer:
             # Comments disabled?


### PR DESCRIPTION
The cause of #105 is wrong continuation tokens and this PR fixes it.

The token at the
```python3
YT_INITIAL_DATA['contents']['twoColumnWatchNextResults']['results.results.contents'][-1]['itemSectionRenderer']['contents'][0]['continuationItemRenderer']['continuationEndpoint']['continuationCommand']['token']
```
should be used, but the current code uses
```python3
YT_INITIAL_DATA['engagementPanels'][-1]['engagementPanelSectionListRenderer']['content']['sectionListRenderer']['contents'][0]['itemSectionRenderer']['contents'][0]['continuationItemRenderer']['continuationEndpoint']['continuationCommand']['token']
```
and fails.