### PR TITLE
fetch count of comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,13 @@ optional arguments:
   --youtubeid YOUTUBEID, -y YOUTUBEID    ID of Youtube video for which to download the comments
   --url URL, -u URL                      Youtube URL for which to download the comments
   --output OUTPUT, -o OUTPUT             Output filename (output format is line delimited JSON)
-  --pretty, -p                           Change the output format to indented JSON
   --limit LIMIT, -l LIMIT                Limit the number of comments
-  --language LANGUAGE, -a LANGUAGE       Language for Youtube generated text (e.g. en)
+  --language LANGUAGE, -a LANGUAGE       Language for Youtube generated text. Defaults to en.
   --sort SORT, -s SORT                   Whether to download popular (0) or recent comments (1). Defaults to 1
+  --template TEMPLATE, -t TEMPLATE
+                        Formatting template using the jsonl fields, e.g., "{author} wrote {time}: {text}". Defaults to None, which outputs the raw JSON.
+  --quote QUOTE, -q QUOTE
+                        enclose values in quotes when filling template. Defaults to False.
 ```
 
 For example:
@@ -46,6 +49,20 @@ youtube-insights --youtubeid ScMzIvxBSi4 --output ScMzIvxBSi4.jsonl
 For Youtube IDs starting with - (dash) you will need to run the script with:
 `-y=idwithdash` or `--youtubeid=idwithdash`
 
+For extracting just the texts, a template can be added:
+```
+youtube-insights --youtubeid ScMzIvxBSi4 --output ScMzIvxBSi4.txt --limit 10 --template "{text}"
+```
+
+Templates can also reference other JSON fields:
+```
+youtube-insights --youtubeid ScMzIvxBSi4 --output ScMzIvxBSi4.txt --limit 10 --template "{author} wrote {time}: {text}"
+```
+
+To export to CSV with author, time, and text:
+```
+youtube-insights --youtubeid ScMzIvxBSi4 --output ScMzIvxBSi4.csv --limit 10 --template "{author},{time},{text}" --quote True
+```
 
 ### Usage as library
 You can also use this script as a library. For instance, if you want to print out the 10 most popular comments for a particular Youtube video you can do the following:

--- a/README.md
+++ b/README.md
@@ -3,22 +3,23 @@ Simple script for downloading Youtube comments without using the Youtube API. Th
 
 ### Installation
 
+Clone the git repository:
+
+```
+git clone https://github.com/schneiderkamplab/youtube-insights.git
+```
+
 Preferably inside a [python virtual environment](https://virtualenv.pypa.io/en/latest/) install this package via:
 
 ```
-pip install youtube-comment-downloader
-```
-
-Or directly from the GitHub repository:
-
-```
-pip install https://github.com/egbertbouman/youtube-comment-downloader/archive/master.zip
+cd youtube-insights
+pip install .
 ```
 
 ### Usage as command-line interface
 ```
-$ youtube-comment-downloader --help
-usage: youtube-comment-downloader [--help] [--youtubeid YOUTUBEID] [--url URL] [--output OUTPUT] [--limit LIMIT] [--language LANGUAGE] [--sort SORT]
+$ youtube-insights --help
+usage: youtube-insights [--help] [--youtubeid YOUTUBEID] [--url URL] [--output OUTPUT] [--limit LIMIT] [--language LANGUAGE] [--sort SORT]
 
 Download Youtube comments without using the Youtube API
 
@@ -35,11 +36,11 @@ optional arguments:
 
 For example:
 ```
-youtube-comment-downloader --url https://www.youtube.com/watch?v=ScMzIvxBSi4 --output ScMzIvxBSi4.json
+youtube-insights --url https://www.youtube.com/watch?v=ScMzIvxBSi4 --output ScMzIvxBSi4.jsonl
 ```
 or using the Youtube ID:
 ```
-youtube-comment-downloader --youtubeid ScMzIvxBSi4 --output ScMzIvxBSi4.json
+youtube-insights --youtubeid ScMzIvxBSi4 --output ScMzIvxBSi4.jsonl
 ```
 
 For Youtube IDs starting with - (dash) you will need to run the script with:
@@ -52,7 +53,7 @@ You can also use this script as a library. For instance, if you want to print ou
 
 ```python
 from itertools import islice
-from youtube_comment_downloader import *
+from youtube_insights import *
 downloader = YoutubeCommentDownloader()
 comments = downloader.get_comments_from_url('https://www.youtube.com/watch?v=ScMzIvxBSi4', sort_by=SORT_BY_POPULAR)
 for comment in islice(comments, 10):

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# youtube-comment-downloader
+# youtube-insights
 Simple script for downloading Youtube comments without using the Youtube API. The output is in line delimited JSON.
 
 ### Installation

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,14 +1,14 @@
 [metadata]
-name = youtube-comment-downloader
+name = youtube-insights
 version = 0.1
-description = Simple script for downloading Youtube comments without using the Youtube API
+description = Simple script for downloading Youtube comments without using the Youtube API, based on Egbert Bouman''s youtube-comment-downloader
 long_description = file: README.md
 long_description_content_type = text/markdown
 license = MIT
 license-file = LICENSE
-url = https://github.com/egbertbouman/youtube-comment-downloader
-author = Egbert Bouman
-author_email = ebouman@gmail.com
+url = https://github.com/schneiderkamplab/youtube-insights
+author = Peter Schneider-Kamp
+author_email = petersk@imada.sdu.dk
 classifiers =
     License :: OSI Approved :: MIT License
     Environment :: Console
@@ -20,6 +20,7 @@ packages = find:
 install_requires =
     dateparser
     requests
+    tqdm
 
 [options.packages.find]
 exclude =
@@ -27,4 +28,4 @@ exclude =
 
 [options.entry_points]
 console_scripts =
-    youtube-comment-downloader = youtube_comment_downloader:main
+    youtube-insights = youtube_insights:main

--- a/youtube_insights/__main__.py
+++ b/youtube_insights/__main__.py
@@ -5,8 +5,8 @@ if __package__ is None:
     path = os.path.realpath(os.path.abspath(__file__))
     sys.path.insert(0, os.path.dirname(os.path.dirname(path)))
 
-import youtube_comment_downloader
+import youtube_insights
 
 
 if __name__ == '__main__':
-    youtube_comment_downloader.main()
+    youtube_insights.main()

--- a/youtube_insights/downloader.py
+++ b/youtube_insights/downloader.py
@@ -145,7 +145,7 @@ class YoutubeCommentDownloader:
         s = next(self.search_dict(data, 'commentCount'), None)['simpleText']
         ss = s.split("\xa0")
         if len(ss) == 1:
-            return int(ss[0].replace(",", ""))
+            return int(ss[0].replace(",", "").replace(".", ""))
         if len(ss) == 2:
             assert(ss[1] == "mio.")
             return int(10**6*float(ss[0].replace(",", ".")))


### PR DESCRIPTION
The initial data contains an estimated count as a text. This PR adds a method for fetching and interpreting this count, allowing e.g. the use of tqdm for monitoring progress.

As an example of the intended use, consider this for a given youtube id:

d = YoutubeCommentDownloader()
total = d.get_count(id)
comments = d.get_comments(id)
for c in tqdm(comments, total=total):
    pass
